### PR TITLE
Rename jsonequal.Equal -> jsonequal.ShouldBeSame

### DIFF
--- a/jsonequal/integration_test.go
+++ b/jsonequal/integration_test.go
@@ -12,11 +12,11 @@ func TestIt(t *testing.T) {
 	b := []byte(`{"foo": 1}`)
 	r := bytes.NewBufferString(`{"foo": 1}`)
 
-	if err := jsonequal.Equal(jsonequal.From(v), jsonequal.FromBytes(b)); err != nil {
+	if err := jsonequal.ShouldBeSame(jsonequal.From(v), jsonequal.FromBytes(b)); err != nil {
 		t.Errorf("mismatch: %s", err)
 	}
 
-	if err := jsonequal.Equal(jsonequal.From(v), jsonequal.FromReader(r)); err != nil {
+	if err := jsonequal.ShouldBeSame(jsonequal.From(v), jsonequal.FromReader(r)); err != nil {
 		t.Errorf("mismatch: %s", err)
 	}
 }

--- a/jsonequal/jsonequal.go
+++ b/jsonequal/jsonequal.go
@@ -58,8 +58,8 @@ func FromBytes(b []byte) func() (interface{}, []byte, error) {
 	}
 }
 
-// Equal :
-func Equal(
+// ShouldBeSame :
+func ShouldBeSame(
 	lsrc func() (interface{}, []byte, error),
 	rsrc func() (interface{}, []byte, error),
 	options ...func(*Caller),
@@ -91,6 +91,15 @@ func Equal(
 		return caller.WrapfFunc(caller.FailFunc(lv, rv, lb, rb), "equal")
 	}
 	return nil
+}
+
+// Equal :
+func Equal(
+	lsrc func() (interface{}, []byte, error),
+	rsrc func() (interface{}, []byte, error),
+	options ...func(*Caller),
+) bool {
+	return ShouldBeSame(lsrc, rsrc, options...) == nil
 }
 
 func defaultFail(

--- a/jsonequal/jsonequal_test.go
+++ b/jsonequal/jsonequal_test.go
@@ -110,7 +110,7 @@ func TestEqual(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.msg, func(t *testing.T) {
-			got := Equal(c.left, c.right)
+			got := ShouldBeSame(c.left, c.right)
 			c.assert(t, got)
 		})
 	}

--- a/snapshot/integration_test.go
+++ b/snapshot/integration_test.go
@@ -10,7 +10,7 @@ import (
 func TestIt(t *testing.T) {
 	got := snapshot.GetData() // see: helper_test.go
 	want := snapshot.Take(t, got)
-	if err := jsonequal.Equal(jsonequal.From(got), jsonequal.From(want)); err != nil {
+	if err := jsonequal.ShouldBeSame(jsonequal.From(got), jsonequal.From(want)); err != nil {
 		t.Errorf("%+v", err)
 	}
 }


### PR DESCRIPTION
Yeah, this is wrong semantics, the function named as `Equal` but return type is error.